### PR TITLE
Issue#182 Fix time_utils to work with UTC

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -119,6 +119,10 @@ class Event(models.Model):
             return datetime.datetime.combine(self.start_date,
                                              datetime.datetime.min.time())
 
+    @property
+    def start_hour(self):
+        return time_utils.as_hour(self.start_datetime())
+
     def _scheduled_items_for_display(self, start=None, end=None):
         result = {'type': 'scheduled_items', 'tracks': []}
         exist_scheduled_item = False

--- a/events/test_time_utils.py
+++ b/events/test_time_utils.py
@@ -1,11 +1,28 @@
 #!/usr/bin/enb python3
 
-import time_utils
 import pytest
+import datetime
+
+import pytz
+
+from . import time_utils
+
+
+def test_as_hour_with_naive_datetime():
+    dst = datetime.datetime(2019, 3, 25, 14, 22, 1, tzinfo=None)
+    assert time_utils.as_hour(dst) == '14:22'
+
+
+def test_as_hour_with_non_naive_datetime():
+    ams = pytz.timezone('CET')
+    dst = datetime.datetime(2019, 3, 25, 14, 22, 1, tzinfo=ams)
+    assert time_utils.as_hour(dst) == '13:22'
 
 
 def test_now():
     t = time_utils.now()
+    assert isinstance(t, datetime.datetime)
+    assert t.tzinfo == pytz.utc
 
 
 def test_now_plus():

--- a/events/test_time_utils.py
+++ b/events/test_time_utils.py
@@ -19,6 +19,12 @@ def test_as_hour_with_non_naive_datetime():
     assert time_utils.as_hour(dst) == '13:22'
 
 
+def test_timestamp():
+    t = time_utils.timestamp(2019, 3, 25, 14, 22, 1)
+    assert isinstance(t, datetime.datetime)
+    assert t.tzinfo == pytz.utc
+
+
 def test_now():
     t = time_utils.now()
     assert isinstance(t, datetime.datetime)

--- a/events/time_utils.py
+++ b/events/time_utils.py
@@ -1,22 +1,45 @@
 #!/usr/bin/env python3
 
-from datetime import datetime as timestamp
-from datetime import timedelta
-from functools import reduce
-from operator import add
+import datetime
+import functools
+import operator
+
+import pytz
+
+
+def as_hour(dst):
+    """Returns the hours and minutes of a datetime (Normalized if appropriate)
+    """
+    if dst.tzinfo is not None and dst.tzinfo != pytz.utc:
+        dst = pytz.utc.normalize(dst)
+    return dst.strftime("%H:%M")
+
+
+def timestamp(year, month, day, hour, minute, second):
+    return datetime.datetime(
+        year, month, day,
+        hour, minute, second,
+        tzinfo=pytz.utc
+        )
+
 
 def now():
-    return timestamp.now()
+    return datetime.datetime.now(pytz.utc)
 
 
 def now_plus(ref=None, days=0, hours=0, minutes=0, seconds=0):
-    steps = [ref or now()]
+    if ref is None:
+        ref = now()
+    else:
+        if ref.tzinfo is not None and ref.tzinfo != pytz.utc:
+            ref = pytz.utc.normalize(ref)
+    steps = [ref]
     if days:
-        steps.append(timedelta(days))
+        steps.append(datetime.timedelta(days))
     if hours:
-        steps.append(timedelta(0, 0, 0, 0, 0, hours))
+        steps.append(datetime.timedelta(0, 0, 0, 0, 0, hours))
     if minutes:
-        steps.append(timedelta(0, 0, 0, 0, minutes))
+        steps.append(datetime.timedelta(0, 0, 0, 0, minutes))
     if seconds:
-        steps.append(timedelta(0, seconds))
-    return reduce(add, steps)
+        steps.append(datetime.timedelta(0, seconds))
+    return functools.reduce(operator.add, steps)


### PR DESCRIPTION
- Functions on `evens/time_utils.py` now return and expects always non-naive datetimes, based on UTC
- Class Event has new property `start_hour`