### PR TITLE
A docker compose for a staging environment

### DIFF
--- a/Dockerfile-gulp
+++ b/Dockerfile-gulp
@@ -16,4 +16,3 @@ RUN npm install && npm cache clean --force --loglevel=error \
 WORKDIR $PYCAN_DIR
 
 ENTRYPOINT ["gulp"]
-CMD ["watch"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# Environment variables that control some of the behaviours in this file:
+# PYCAN_DB_PORT=5432
+# PYCAN_APP_PORT=8000
+
 version: '3'
 services:
     database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
             # But hide the host's node_modules by creating an anonymous volume
             # This is called "The node_modules volume trick"
             - /var/www/pycan/node_modules
+        command: watch
 volumes:
     database-data:
     web-media:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
             DATABASE_PASSWORD: pycan_password
             DATABASE_HOST: database
             MEDIA_ROOT: /var/www/media
+            STATIC_ROOT: /var/www/static
+
     gulp:
         build:
             context: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ reportlab==3.5.32
 rq==1.1.0
 sendgrid==5.6.0
 stripe==2.41.0
+uWSGI==2.0.18
 xlrd==1.2.0
 xlwt==1.3.0

--- a/tools/docker-compose.staging.yml
+++ b/tools/docker-compose.staging.yml
@@ -1,0 +1,35 @@
+# This file is meant to be used in conjunction with the docker-compose.yml
+# file one level up. The purpose is to test the app in an environment that
+# is closer to production.
+#
+# Environment variables that control some of the behaviours in this file:
+# PYCAN_STAGING_PORT=10080
+
+version: '3'
+services:
+  pycan_web:
+    volumes:
+      - web-socket:/tmp/pycan/
+      - web-static:/var/www/static/
+    entrypoint: []
+    command: ./tools/staging_app_entrypoint.sh
+
+  nginx:
+    image: nginx:1.14.0
+    restart: always
+    volumes:
+      - ./tools/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./tools/nginx/pycan_web.nginx:/etc/nginx/pycan_web.nginx:ro
+      - web-socket:/tmp/pycan/
+      - web-media:/var/www/media/
+      - web-static:/var/www/static/
+    ports:
+      - "${PYCAN_STAGING_PORT:-10080}:80"
+    command: nginx -g "daemon off;"
+
+  gulp:
+    command: ""
+
+volumes:
+  web-static:
+  web-socket:

--- a/tools/nginx/nginx.conf
+++ b/tools/nginx/nginx.conf
@@ -1,0 +1,26 @@
+user root;
+worker_processes 1;
+
+error_log  /var/log/nginx/error.log debug;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    include /etc/nginx/*.nginx;
+}

--- a/tools/nginx/pycan_web.nginx
+++ b/tools/nginx/pycan_web.nginx
@@ -1,0 +1,23 @@
+upstream uwsgi {
+    server unix:/tmp/pycan/web.sock;
+}
+
+server {
+    listen 80;
+    server_name local.pythoncanarias.es;
+
+    client_max_body_size 20M;
+
+    location / {
+        include uwsgi_params;
+        uwsgi_pass uwsgi;
+    }
+
+    location /static {
+        root /var/www;
+    }
+
+    location /media {
+        root /var/www;
+    }
+}

--- a/tools/staging_app_entrypoint.sh
+++ b/tools/staging_app_entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+python manage.py migrate
+python manage.py collectstatic --noinput --clear
+exec uwsgi --ini uwsgi.ini --socket /tmp/pycan/web.sock


### PR DESCRIPTION
Add a second docker-compose file `docker-compose.staging.yml` to be used in combination with the main one. The purpose is to launch the web app in an environment that resembles that of production more closely (using `uwsgi` and `nginx`) so that PRs can be tested better before deploying and surprises are minimized.

Running the dev version like this as before:

    docker-compose up

Running the new staging version by combining both compose files:

    docker-compose -f docker-compose.yml -f tools/docker-compose.staging.yml up